### PR TITLE
Change URL to point to the commit, if a single commit.

### DIFF
--- a/pagure_notifications/git.receive.j2
+++ b/pagure_notifications/git.receive.j2
@@ -10,5 +10,18 @@
     {% endif %}
     to <code>{{json.msg.branch}}</code> branch of <strong>{{json.msg.project_fullname}}</strong>
     <br/>
-    </a>
+    </a>.
+    The commit(s) changed {{json.msg.changed_files}}
+    {% if len(json.msg.changed_files) < 1 %}
+    NO files.
+    {% elif len(json.msg.changed_files) > 4 %}
+    {% len(json.msg.changed_files) %} files (too many to show).
+    {% else %}
+    {% len(json.msg.changed_files) %} files:<ul>
+    {% for fname in sorted(json.msg.changed_files.keys()) %}
+    <li>{{ fname }} - {{ json.msg.changed_files[fname] }}</li>
+    {% endfor %}
+    </ul>
+    {% endif %}
+
 </p>

--- a/pagure_notifications/git.receive.j2
+++ b/pagure_notifications/git.receive.j2
@@ -1,5 +1,9 @@
 <p>
+    {% if json.msg.total_commits == 1 %}
+    <a href="{{json.msg.repo.full_url}}/c/{{json.msg.end_commit}}">
+    {% else %}
     <a href="{{json.msg.repo.full_url}}/c/{{json.msg.start_commit}}..{{json.msg.end_commit}}">
+    {% endif %}
     <strong><span data-mx-bg-color="#28a745" data-mx-color="#ffffff" data-mx-bg-color="#3c6eb4">{{json.msg.agent}} pushed {{json.msg.total_commits}} commit(s)</span></strong>
     {% if json.msg.authors[0].name != json.msg.agent %}
     by {{json.msg.authors[0].name}}


### PR DESCRIPTION
Matrix shows a "summary" of the URL, and the pagure diff URLs are horrifically bad that way (always shows 0 files/lines changed). This changes the template to point to the commit, if there is just a single commit.
It still doesn't look amazing, but you can see the subject and the files/lines changed is correct.